### PR TITLE
Add Dockerfile to fix build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use an official Python runtime as a parent image
+FROM python:3.11-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Install git so we can install the mcp dependency from github
+RUN apt-get update && apt-get install -y git
+
+# Copy the requirements file into the container at /app
+COPY requirements.txt .
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application's code to the container
+COPY . .
+
+# Run monster_server.py when the container launches
+CMD ["python", "monster_server.py"]


### PR DESCRIPTION
The build was failing because a Dockerfile was missing and the auto-generated one was incorrect. The Python SDK in use requires Python 3.10 or higher, but the default base image was using an older version.

This change adds a Dockerfile that:
- Uses a python:3.11-slim base image.
- Installs git to be able to install dependencies from git repositories.
- Installs dependencies from requirements.txt.
- Sets the default command to run the application.