### PR TITLE
Fix deployment error by using PORT environment variable

### DIFF
--- a/monster_server.py
+++ b/monster_server.py
@@ -251,5 +251,8 @@ async def get_job_details(job_query: str, session_id: Optional[str] = None) -> s
         return f"Error retrieving job details: {str(e)}"
 
 
+import os
+
 if __name__ == "__main__":
-    mcp.run()
+    port = int(os.environ.get("PORT", 8080))
+    mcp.run(host="0.0.0.0", port=port)


### PR DESCRIPTION
The previous deployment failed because the application was not listening on the port provided by the deployment environment. This resulted in a `deployError`.

This change modifies `monster_server.py` to:
- Read the `PORT` environment variable.
- Start the server on host `0.0.0.0` and the specified port.

This also includes the `Dockerfile` from the previous attempt, which is still necessary.