### PR TITLE
Fix 'Scan failed' error by adding exampleConfig to smithery.yaml

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -5,6 +5,7 @@ startCommand:
   configSchema:
     type: "object"
     properties: {}
+  exampleConfig: {}
 build:
   dockerfile: "Dockerfile"
 env:


### PR DESCRIPTION
The server scan was failing with the error "No test configuration found for this server. Using a best guess." This suggests that the scanner was unable to determine how to connect to the server.

By adding an empty `exampleConfig: {}` to `smithery.yaml`, we provide an explicit configuration for the scanner to use. This should resolve the ambiguity and allow the scan to complete successfully for a server that requires no configuration.