### PR TITLE
Fix server startup using documented mcp.run method

### DIFF
--- a/monster_server.py
+++ b/monster_server.py
@@ -252,29 +252,7 @@ async def get_job_details(job_query: str, session_id: Optional[str] = None) -> s
 
 
 import os
-import uvicorn
-from starlette.middleware.cors import CORSMiddleware
 
 if __name__ == "__main__":
-    # HTTP mode with config extraction from URL parameters
-    print("Monster Job Search MCP Server starting in HTTP mode...")
-
-    # Setup Starlette app with CORS for cross-origin requests
-    app = mcp.streamable_http_app()
-
-    # IMPORTANT: add CORS middleware for browser based clients
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=True,
-        allow_methods=["GET", "POST", "OPTIONS"],
-        allow_headers=["*"],
-        expose_headers=["mcp-session-id", "mcp-protocol-version"],
-        max_age=86400,
-    )
-
-    # Get port from environment variable (defaults to 8080)
     port = int(os.environ.get("PORT", 8080))
-    print(f"Listening on port {port}")
-
-    uvicorn.run(app, host="0.0.0.0", port=port, log_level="debug")
+    mcp.run(transport="http", host="0.0.0.0", port=port)


### PR DESCRIPTION
This change corrects the server startup mechanism in monster_server.py. Previous attempts used a more complex setup with uvicorn and CORS middleware, which was incorrect for the version of the FastMCP library in use.

This commit reverts to the simpler, documented method of calling `mcp.run(transport="http", ...)` which should correctly start the HTTP server and resolve the persistent "Scan failed" error.