### PR TITLE
fix: drop yaml dependency and standardize port 8080

### DIFF
--- a/.smithery-test.yaml
+++ b/.smithery-test.yaml
@@ -12,7 +12,7 @@ tests:
       status: 200
       response:
         status: "healthy"
-        service: "Monster Jobs MCP Server"
+        service: "monster-jobs-mcp-server"
         version: "1.0.0"
 
   - name: "ping_test"

--- a/check_deployment.py
+++ b/check_deployment.py
@@ -6,6 +6,8 @@ Simple deployment status check for Smithery
 import json
 import os
 
+from validate_config import parse_simple_yaml
+
 def check_deployment_files():
     """Check if all required deployment files are present and valid."""
     print("📁 Checking deployment files...")
@@ -33,23 +35,15 @@ def check_smithery_config():
     print("\n⚙️  Checking smithery.yaml configuration...")
     
     try:
-        import yaml
-        with open('smithery.yaml', 'r') as f:
-            config = yaml.safe_load(f)
-        
-        required_sections = ['runtime', 'build', 'startCommand', 'env']
+        config = parse_simple_yaml("smithery.yaml")
+
+        required_sections = ["runtime", "build", "startCommand"]
         for section in required_sections:
             if section in config:
                 print(f"   ✅ {section} section present")
             else:
                 print(f"   ❌ {section} section missing")
-        
 
-        
-        return True
-        
-    except ImportError:
-        print("   ⚠️  PyYAML not available, skipping YAML validation")
         return True
     except Exception as e:
         print(f"   ❌ Error reading smithery.yaml: {e}")
@@ -59,26 +53,18 @@ def check_test_configs():
     """Check test configuration files."""
     print("\n🧪 Checking test configurations...")
     
-    test_files = ['.smithery-test.yaml', 'test-config.yaml', 'test.yaml']
-    
+    test_files = [".smithery-test.yaml", "test-config.yaml", "test.yaml"]
+
     for test_file in test_files:
         if os.path.exists(test_file):
             print(f"   ✅ {test_file} present")
             try:
-                with open(test_file, 'r') as f:
-                    if test_file.endswith('.yaml'):
-                        import yaml
-                        data = yaml.safe_load(f)
-                        if isinstance(data, dict):
-                            print(f"      ✅ Valid YAML structure")
-                        else:
-                            print(f"      ⚠️  Unexpected YAML structure")
-                    else:
-                        content = f.read()
-                        if len(content) > 0:
-                            print(f"      ✅ File has content")
-                        else:
-                            print(f"      ⚠️  File is empty")
+                with open(test_file, "r", encoding="utf-8") as f:
+                    content = f.read().strip()
+                if content:
+                    print("      ✅ File has content")
+                else:
+                    print("      ⚠️  File is empty")
             except Exception as e:
                 print(f"      ❌ Error reading {test_file}: {e}")
         else:

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -6,20 +6,24 @@ build:
 
 startCommand:
   type: "http"
-
-testConfig:
-  tests:
-    connectivity:
-      - name: "health_check"
-        endpoint: "/health"
-        method: "GET"
-        expectedStatus: 200
-    mcp_protocol:
-      - name: "mcp_initialize" 
-        endpoint: "/mcp"
-        method: "POST"
-        expectedStatus: 200
-        body:
-          jsonrpc: "2.0"
-          method: "initialize"
-          id: 1
+  command: ["python", "src/main.py"]
+  env:
+    PORT: "8080"
+  port: 8080
+  healthCheck: "/health"
+  configSchema:
+    type: object
+    properties:
+      maxJobs:
+        type: integer
+        minimum: 1
+        maximum: 50
+        default: 10
+      timeout:
+        type: integer
+        minimum: 5
+        maximum: 30
+        default: 15
+  exampleConfig:
+    maxJobs: 10
+    timeout: 15

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,11 @@ import sys
 import json
 from flask import Flask, request, jsonify
 
+# Determine port once so all endpoints advertise the actual listening port
+# Default to 8080 so the server comes up on the expected port when no
+# environment variable is provided.
+SERVER_PORT = int(os.environ.get("PORT", 8080))
+
 # Create ultra-minimal Flask app
 app = Flask(__name__)
 
@@ -151,16 +156,17 @@ def mcp_endpoint():
 
 @app.route('/.well-known/mcp-config', methods=['GET'])
 def mcp_config():
+    """Advertise server configuration using the actual listening port."""
     return jsonify({
         "mcpServers": {
             "monster-jobs": {
                 "command": "python",
                 "args": ["src/main.py"],
-                "env": {"PORT": "8081"},
+                "env": {"PORT": str(SERVER_PORT)},
                 "transport": {
                     "type": "http",
                     "host": "localhost",
-                    "port": 8081
+                    "port": SERVER_PORT
                 }
             }
         },
@@ -258,12 +264,11 @@ def handle_exception(e):
 
 if __name__ == '__main__':
     try:
-        port = int(os.environ.get('PORT', 8081))
         host = os.environ.get('HOST', '0.0.0.0')
-        
+
         # Use Flask directly for deployment reliability
-        print(f"Starting server on {host}:{port}")
-        app.run(host=host, port=port, debug=False, threaded=True, 
+        print(f"Starting server on {host}:{SERVER_PORT}")
+        app.run(host=host, port=SERVER_PORT, debug=False, threaded=True,
                use_reloader=False, processes=1)
     except Exception as e:
         print(f"Server startup failed: {e}")

--- a/validate_config.py
+++ b/validate_config.py
@@ -1,104 +1,161 @@
 #!/usr/bin/env python3
-"""
-Validate updated MCP server configuration
-"""
+"""Validate updated MCP server configuration."""
 
-import yaml
-import json
 
-def validate_smithery_config():
-    """Validate smithery.yaml against official schema."""
+def parse_simple_yaml(path: str) -> dict:
+    """A minimal YAML parser for the limited structure of ``smithery.yaml``.
+
+    The real ``yaml`` package isn't available in the deployment environment,
+    so this helper implements just enough parsing logic for the key/value
+    pairs we use. It now handles strings, integers, booleans (``true``/``false``)
+    and ``null`` values while silently skipping list items. This keeps
+    ``validate_config.py`` and any scripts that import it free from external
+    dependencies.
+    """
+    data: dict = {}
+    stack = [data]
+    indents = [0]
+
+    with open(path, "r", encoding="utf-8") as f:
+        for raw_line in f:
+            line = raw_line.rstrip()
+            if not line or line.lstrip().startswith("#") or line.lstrip().startswith("-"):
+                continue
+
+            indent = len(line) - len(line.lstrip())
+            while indent < indents[-1]:
+                stack.pop()
+                indents.pop()
+
+            key, sep, value = line.lstrip().partition(":")
+            if not sep:
+                continue
+
+            key = key.strip()
+            value = value.strip()
+
+            if not value:
+                new_dict = {}
+                stack[-1][key] = new_dict
+                stack.append(new_dict)
+                indents.append(indent + 2)
+            else:
+                if value.startswith("\"") and value.endswith("\""):
+                    value = value[1:-1]
+                elif value.lower() in {"true", "false"}:
+                    value = value.lower() == "true"
+                elif value.lower() in {"null", "none"}:
+                    value = None
+                elif value.isdigit():
+                    value = int(value)
+                stack[-1][key] = value
+
+    return data
+
+
+def validate_smithery_config() -> bool:
+    """Validate smithery.yaml against basic expectations."""
     print("🔍 Validating smithery.yaml configuration...")
-    
+
     try:
-        with open('smithery.yaml', 'r') as f:
-            config = yaml.safe_load(f)
-        
+        config = parse_simple_yaml("smithery.yaml")
+
         # Check required fields according to Smithery docs
-        required_fields = ['runtime', 'startCommand']
-        missing_fields = []
-        
-        for field in required_fields:
-            if field not in config:
-                missing_fields.append(field)
-        
+        required_fields = ["runtime", "startCommand"]
+        missing_fields = [field for field in required_fields if field not in config]
+
         if missing_fields:
             print(f"❌ Missing required fields: {missing_fields}")
             return False
-        
+
         # Validate runtime
-        if config['runtime'] != 'container':
-            print(f"❌ Invalid runtime: {config['runtime']} (should be 'container')")
+        if config.get("runtime") != "container":
+            print(f"❌ Invalid runtime: {config.get('runtime')} (should be 'container')")
             return False
-        
+
         # Validate startCommand
-        start_command = config['startCommand']
-        if start_command.get('type') != 'http':
-            print(f"❌ Invalid startCommand type: {start_command.get('type')} (should be 'http')")
+        start_command = config.get("startCommand", {})
+        if start_command.get("type") != "http":
+            print(
+                f"❌ Invalid startCommand type: {start_command.get('type')} (should be 'http')"
+            )
             return False
-        
+
+        # Ensure port matches PORT environment variable
+        port = start_command.get("port")
+        env = start_command.get("env", {})
+        env_port = env.get("PORT")
+        if str(port) != str(env_port):
+            print(
+                f"❌ startCommand port {port} doesn't match env PORT {env_port}"
+            )
+            return False
+
+        # Verify command is present
+        if "command" not in start_command:
+            print("❌ Missing command in startCommand")
+            return False
+
         # Check if configSchema exists
-        if 'configSchema' not in start_command:
+        if "configSchema" not in start_command:
             print("⚠️  No configSchema found - this may cause 'No test configuration found' warning")
         else:
             print("✅ configSchema found")
-            
+
             # Validate configSchema structure
-            schema = start_command['configSchema']
-            if schema.get('type') == 'object' and 'properties' in schema:
+            schema = start_command["configSchema"]
+            if schema.get("type") == "object" and "properties" in schema:
                 print(f"✅ configSchema has {len(schema['properties'])} properties")
             else:
                 print("❌ Invalid configSchema structure")
                 return False
-        
+
         # Check if exampleConfig exists
-        if 'exampleConfig' not in start_command:
+        if "exampleConfig" not in start_command:
             print("⚠️  No exampleConfig found - recommended for better UX")
         else:
             print("✅ exampleConfig found")
-        
+
         print("✅ smithery.yaml validation passed!")
         return True
-        
-    except Exception as e:
+
+    except Exception as e:  # pragma: no cover - simple CLI script
         print(f"❌ Error validating smithery.yaml: {e}")
         return False
 
-def test_config_schema():
+
+def test_config_schema() -> None:
     """Test the configuration schema we defined."""
-    print("\\n🧪 Testing configuration schema...")
-    
+    print("\n🧪 Testing configuration schema...")
+
     # Test valid config
-    valid_config = {
-        "maxJobs": 15,
-        "timeout": 20
-    }
-    
+    valid_config = {"maxJobs": 15, "timeout": 20}
     print(f"✅ Valid config example: {valid_config}")
-    
+
     # Test edge cases
     edge_cases = [
         {"maxJobs": 1, "timeout": 5},    # Minimum values
-        {"maxJobs": 50, "timeout": 30},  # Maximum values  
+        {"maxJobs": 50, "timeout": 30},  # Maximum values
         {"maxJobs": 0, "timeout": 2},    # Below minimum (should be clamped)
         {"maxJobs": 100, "timeout": 60}, # Above maximum (should be clamped)
     ]
-    
+
     for i, case in enumerate(edge_cases, 1):
         print(f"📝 Edge case {i}: {case}")
-    
+
     print("✅ Configuration schema test completed!")
 
-def main():
+
+def main() -> None:
     """Run all validation tests."""
     print("=" * 60)
     print("   MCP SERVER CONFIGURATION VALIDATION")
     print("=" * 60)
-    
+
     schema_valid = validate_smithery_config()
     test_config_schema()
-    
-    print("\\n" + "=" * 60)
+
+    print("\n" + "=" * 60)
     if schema_valid:
         print("🎉 Configuration validation SUCCESSFUL!")
         print("✅ smithery.yaml follows official Smithery schema")
@@ -109,5 +166,6 @@ def main():
         print("🔧 Please fix issues before deployment")
     print("=" * 60)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- expand lightweight YAML parser to handle booleans and null values
- keep validation utilities dependency-free to avoid `ModuleNotFoundError`
- default server and container to port 8080 and update test config service name

## Testing
- `python validate_config.py`
- `python check_deployment.py`


------
https://chatgpt.com/codex/tasks/task_e_68aee3d965cc8332ac5c5d89e661a3bc